### PR TITLE
controlpad.js refactor

### DIFF
--- a/controller/app.js
+++ b/controller/app.js
@@ -1,4 +1,4 @@
-import { send_controlpad_message, CONTROLPAD_MESSAGE } from "./controlpad.js";
+import { send_controlpad_message } from "./controlpad.js";
 
 
 // set to true to enable logs from controlpad.js

--- a/controller/app.js
+++ b/controller/app.js
@@ -1,4 +1,17 @@
-import { send_controlpad_message } from "./controlpad.js";
+import { send_controlpad_message, CONTROLPAD_MESSAGE } from "./controlpad.js";
+
+
+// DEBUG is a global variable that can be used to enable or disable console messages
+export const DEBUG = false;
+
+document.addEventListener(CONTROLPAD_MESSAGE, (event) => {
+    if(event.detail === "goodbye") {
+        console.log("Goodbye");
+        send_controlpad_message("cya");
+    }
+});
+
+
 
 //////////////////////////////// Layout Elements ///////////////////////////////
 
@@ -27,6 +40,18 @@ function layoutElements(isPortrait, viewWidth, viewHeight) {
     }
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+
+/////////////////////// EXAMPLE BUTTON LISTENER START //////////////////////////
+
+document.getElementById("enter-button").addEventListener("click", () => {
+    send_controlpad_message("hello");
+});
+
+document.getElementById("enter-button-landscape").addEventListener("click", () => {
+    send_controlpad_message("hello");
+});
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/controller/app.js
+++ b/controller/app.js
@@ -1,16 +1,9 @@
 import { send_controlpad_message, CONTROLPAD_MESSAGE } from "./controlpad.js";
 
 
-// DEBUG is a global variable that can be used to enable or disable console messages
+// set to true to enable logs from controlpad.js
+// make sure to set to false before submitting your code
 export const DEBUG = false;
-
-document.addEventListener(CONTROLPAD_MESSAGE, (event) => {
-    if(event.detail === "goodbye") {
-        console.log("Goodbye");
-        send_controlpad_message("cya");
-    }
-});
-
 
 
 //////////////////////////////// Layout Elements ///////////////////////////////
@@ -42,19 +35,6 @@ function layoutElements(isPortrait, viewWidth, viewHeight) {
 
 
 ////////////////////////////////////////////////////////////////////////////////
-
-/////////////////////// EXAMPLE BUTTON LISTENER START //////////////////////////
-
-document.getElementById("enter-button").addEventListener("click", () => {
-    send_controlpad_message("hello");
-});
-
-document.getElementById("enter-button-landscape").addEventListener("click", () => {
-    send_controlpad_message("hello");
-});
-
-////////////////////////////////////////////////////////////////////////////////
-
 
 // prevent usage of input box from causing elements to scroll out of view (this
 // is a default behavior we are essentially overriding)

--- a/controller/controlpad.js
+++ b/controller/controlpad.js
@@ -31,13 +31,19 @@ class GameWebSocket {
         this.socket.onmessage = this.onmessage.bind(this);
     }
 
+    // send initial message to the controlpad server after the WebSocket connection is opened
+    // Method to send initial messages once the WebSocket connection is ready
+    sendInitialMessages() {
+        const byte_array = new Uint8Array(1);
+        byte_array[0] = this.subid;
+        this.socket.send(byte_array);
+        this.socket.send("state-request");
+    }
+    
     // event handler for the WebSocket onopen event   
     onopen = async (_event) => {
         console.log("opened websocket on " + this.ip + ":" + this.port);
-        this.socket.send("state-request");
-        const byte_array = new Uint8Array(1);
-        byte_array[0] = this.subid;
-        this.socket.send(byte_array);        
+        this.sendInitialMessages();
     }
 
     // event handler for the WebSocket onclose event
@@ -47,6 +53,7 @@ class GameWebSocket {
 
     // event handler for the Websocket onmessage event
     onmessage = async (event) => {
+        console.log("Received message:", event.data);
         if (event.data instanceof Blob) {
             // Read the Blob as a Uint8Array
             const blobData = new Uint8Array(await event.data.arrayBuffer()); 
@@ -76,9 +83,9 @@ class GameWebSocket {
 }
 
 // Create a new WebSocket object
-const socket = new GameWebSocket();
+const ws = new GameWebSocket();
 
 export function send_controlpad_message(msg) {
     console.log('sending ' + msg);
-    socket.send(msg);
+    ws.socket.send(msg);
 }

--- a/controller/controlpad.js
+++ b/controller/controlpad.js
@@ -10,8 +10,8 @@ const url_params = new URLSearchParams(url_arg_str);
 class GameWebSocket {
     /**
      * Create a new WebSocket object
-     * @param {string} ip - The IP address of the controlpad server
-     * @param {number} subid - The subid of the controlpad server
+     * @param {string} ip - The IP address of the console
+     * @param {number} subid - The subid of the phone client
      * @param {number} port - The port number of the controlpad server
      */    
     constructor(port = 50079) {

--- a/controller/controlpad.js
+++ b/controller/controlpad.js
@@ -3,19 +3,32 @@
    relying on edits you make to this file may break your game.
 */
 
+export const CONTROLPAD_MESSAGE = "controlpad-message";
+
 const url_arg_str = window.location.search;
 const url_params = new URLSearchParams(url_arg_str);
+
+var _DEBUG = false;
+
+(async () => {
+    const appModule = await import('./app.js');
+    if ('DEBUG' in appModule) {
+        console.log('DEBUG mode:', appModule.DEBUG);
+        _DEBUG = appModule.DEBUG;
+    }
+})();
 
 // WebSocket class to handle communication with the controlpad server
 class GameWebSocket {
     /**
      * Create a new WebSocket object
-     * @param {string} ip - The IP address of the console
-     * @param {number} subid - The subid of the phone client
+     * @type {string} ip - The IP address of the console
+     * @type {number} subid - The subid of the phone client
      * @param {number} port - The port number of the controlpad server
      */    
     constructor(port = 50079) {
         this.ip = window.location.href.split('/')[2].split(':')[0];
+        // default subid is 0. If the subid is null, it will be casted to 0
         this.subid = url_params.get('subid');
         this.port = port;
         this.socket = null;
@@ -35,6 +48,8 @@ class GameWebSocket {
     // Method to send initial messages once the WebSocket connection is ready
     sendInitialMessages() {
         const byte_array = new Uint8Array(1);
+        // if subid is null, it will get coerced into 0 because Uint8 can only
+        // contain unsigned bytes
         byte_array[0] = this.subid;
         this.socket.send(byte_array);
         this.socket.send("state-request");
@@ -42,29 +57,36 @@ class GameWebSocket {
     
     // event handler for the WebSocket onopen event   
     onopen = async (_event) => {
-        console.log("opened websocket on " + this.ip + ":" + this.port);
+        if(_DEBUG) {
+            console.log("WebSocket opened on " + this.ip + ":" + this.port);
+        }
         this.sendInitialMessages();
     }
 
     // event handler for the WebSocket onclose event
     onclose = () => {
-        console.log("closing websocket on " + this.ip + ":" + this.port);
+        if(_DEBUG) {
+            console.log("WebSocket closed on " + this.ip + ":" + this.port);
+        }
     }
 
     // event handler for the Websocket onmessage event
     onmessage = async (event) => {
-        console.log("Received message:", event.data);
+        if(_DEBUG) {
+            console.log("Received message:", event.data);
+        }
         if (event.data instanceof Blob) {
             // Read the Blob as a Uint8Array
             const blobData = new Uint8Array(await event.data.arrayBuffer()); 
             // Check the first byte to trigger a reload if it's equal to 0x01
             if (blobData.length > 0 && blobData[0] === 0x01) {
-                console.log("Hold your hats! It's reload time!");
                 location.reload();
             }
             else {
                 // Handle other binary data
-                console.log("Received binary data:", blobData);
+                if(_DEBUG){
+                    console.log("Received binary data:", blobData);
+                }
                 // Handle it according to your use case.
             }
         }
@@ -78,7 +100,9 @@ class GameWebSocket {
 
     // event handler for the WebSocket onerror event
     onerror = (error) => {
-        console.log("WebSocket error:", error, " on " + this.ip + ":" + this.port);
+        if(_DEBUG) {
+            console.log("WebSocket error:", error, " on " + this.ip + ":" + this.port);
+        }
     }
 }
 


### PR DESCRIPTION
REASON FOR REFACTOR
- cleaner code / easier for devs to understand what's going on 
- proper message handling according to WebSockets Standard: https://websockets.spec.whatwg.org/#dom-websocket-onmessage

change and reason for change
-------------------------------------------------------------------------
CHANGE:  moved onmessage outside of onopen
REASON: 
- onopen when successful changes the websockets ready_state to OPEN(1)

> When [the WebSocket connection is established](https://datatracker.ietf.org/doc/html/rfc6455#page-19:~:text=_The%20WebSocket%20Connection%20is%20Established_,-and), the user agent must [queue a task](https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task) to run these steps:

>    Change the [ready state](https://websockets.spec.whatwg.org/#websocket-ready-state) to [OPEN](https://websockets.spec.whatwg.org/#dom-websocket-open) (1).

- onmessage only runs when the websockets ready state is OPEN(1) See below:

> When [a WebSocket message has been received](https://datatracker.ietf.org/doc/html/rfc6455#page-66:~:text=_A%20WebSocket%20Message%20Has%20Been%20Received_) with type type and data data, the user agent must [queue a task](https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task) to follow these steps: [[WSP]](https://websockets.spec.whatwg.org/#biblio-wsp)

>    If [ready state](https://websockets.spec.whatwg.org/#websocket-ready-state) is not [OPEN](https://websockets.spec.whatwg.org/#dom-websocket-open) (1), then return.

- so keeping onmessage inside the onopen method is unnecessary as it will only run when the websockets ready_state is 1 and keeping it inside open violates single authority

-------------------------------------------------------------------------
CHANGE: put the websocket code in a class
REASON: Sets up all websocket listeners through a singular method rather than on each event + readability, organization.

-------------------------------------------------------------------------
CHANGE: update var name of ws to socket
REASON: just for clarity purposes 

-------------------------------------------------------------------------
CHANGE: added an onerror
REASON: to capture any websocket errors